### PR TITLE
chore(github): Shorten security workflow job names

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,5 +1,5 @@
 ---
-name: Security Scan
+name: Security
 on:
   push: {}
   pull_request: {}
@@ -7,5 +7,5 @@ on:
     - cron: '0 0 * * *'
 jobs:
   supply-chain-security-validation:
-    name: Supply Chain Security Validation
+    name: Supply Chain
     uses: coopnorge/github-workflow-supply-chain-security-validation/.github/workflows/supply-chain-security-validation.yaml@main


### PR DESCRIPTION
Shortens the titles of security workflows to fit in GitHub's UI. See coopnorge/github-workflow-supply-chain-security-validation#53